### PR TITLE
Enhancements 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: all tests runtests clean install 
 
+
+OS = ubuntu16.04
+
 LLIST_OPTS   = 
 CFLAGS       = -g -Wall -pedantic -std=gnu99 -Iinclude
 EXTRA_FLAGS  = -fPIC -shared -fprofile-arcs -ftest-coverage
@@ -8,6 +11,10 @@ LDFLAGS	     = -shared
 DEBUGFLAGS   = -O0 -D _DEBUG
 RELEASEFLAGS = -O2 -D NDEBUG -combine -fwhole-program
 TEST_LDFLAGS = -lcheck -lpthread -lllist -lm -lrt
+
+ifeq ($(OS),ubuntu16.04)
+   TEST_LDFLAGS += -lsubunit
+endif
 
 OBJDIR	= lib
 TARGET  = $(OBJDIR)/libllist.so
@@ -27,7 +34,7 @@ $(TARGET): $(OBJECTS)
 	$(CC) $(FLAGS) $(LIBFLAGS) $(DEBUGFLAGS) -o $(TARGET) $(OBJECTS)
 
 tests: $(TEST_OBJECTS)
-	$(CC) $(FLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) $(TEST_LDFLAGS)
+	$(CC) $(FLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) $(TEST_LDFLAGS) -L$(OBJDIR)/
 
 # Need a special rule to compile the lib to allow EXTRA_FLAGS
 $(OBJECTS): $(SOURCES) $(HEADERS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all tests runtests clean install 
 
 
-OS = ubuntu16.04
+OS =
 
 LLIST_OPTS   = 
 CFLAGS       = -g -Wall -pedantic -std=gnu99 -Iinclude

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all tests runtests clean install 
 
 
-OS =ubuntu16.04
+OS =
 
 LLIST_OPTS   = 
 CFLAGS       = -g -Wall -pedantic -std=gnu99 -Iinclude

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all tests runtests clean install 
 
 
-OS =
+OS =ubuntu16.04
 
 LLIST_OPTS   = 
 CFLAGS       = -g -Wall -pedantic -std=gnu99 -Iinclude
@@ -34,7 +34,7 @@ $(TARGET): $(OBJECTS)
 	$(CC) $(FLAGS) $(LIBFLAGS) $(DEBUGFLAGS) -o $(TARGET) $(OBJECTS)
 
 tests: $(TEST_OBJECTS)
-	$(CC) $(FLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) $(TEST_LDFLAGS) -L$(OBJDIR)/
+	$(CC) $(FLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) $(TEST_LDFLAGS) -L$(OBJDIR)
 
 # Need a special rule to compile the lib to allow EXTRA_FLAGS
 $(OBJECTS): $(SOURCES) $(HEADERS)

--- a/inc/llist.h
+++ b/inc/llist.h
@@ -33,9 +33,9 @@ typedef enum
 	LLIST_COMPERATOR_MISSING,		/**< Error: Comparator function is missing*/
 	LLIST_NULL_ARGUMENT,			/**< Error: NULL argument*/
 	LLIST_MALLOC_ERROR,				/**< Error: Memory allocation error*/
-    LLIST_NOT_IMPLEMENTED,          /**< Error: Implementation missing*/
-    LLIST_MULTITHREAD_ISSUE,        /**< Error: Multithreading issue*/
-	LLIST_ERROR						/**< Error: Generic error*/
+        LLIST_NOT_IMPLEMENTED,          /**< Error: Implementation missing*/
+        LLIST_MULTITHREAD_ISSUE,        /**< Error: Multithreading issue*/
+	LLIST_ERROR,			/**< Error: Generic error*/
 } E_LLIST;
 
 #define ADD_NODE_FRONT		(1 << 0)
@@ -49,6 +49,9 @@ typedef enum
 
 #define MT_SUPPORT_TRUE  (1)
 #define MT_SUPPORT_FALSE (0)
+
+#define LOOP_ABORT_TRUE (1)
+#define LOOP_ABORT_FALSE (1)
 
 #undef TRUE
 #undef FALSE
@@ -148,15 +151,24 @@ int llist_delete_node ( llist list, llist_node node, equal alternative, bool des
 int llist_find_node ( llist list, void * data, llist_node * found, equal alternative );
 
 /**
- * @brief operate on each element of the list
+ * @brief operate on each element of the list, not thread safe if func modifies node contents
  * @param[in] list the list to operator upon
- * @param[in] func the function to perform
+ * @param[in] func
  * @return int LLIST_SUCCESS if success
  */
 int llist_for_each ( llist list, node_func func );
 
 /**
- * @brief operate on each element of the list
+ * @brief operate(R) on each element of the list
+ * @param[in] list the list to operator upon
+ * @param[in] r_only_func the function to perform
+ * @param[in] arg passed to func
+ * @return int LLIST_SUCCESS if success
+ */
+int llist_for_each_arg_read_only ( llist list, node_func_arg r_only_func, void * arg);
+
+/**
+ * @brief operate(R/W) on each element of the list
  * @param[in] list the list to operator upon
  * @param[in] func the function to perform
  * @param[in] arg passed to func

--- a/inc/llist.h
+++ b/inc/llist.h
@@ -35,7 +35,7 @@ typedef enum
 	LLIST_MALLOC_ERROR,				/**< Error: Memory allocation error*/
         LLIST_NOT_IMPLEMENTED,          /**< Error: Implementation missing*/
         LLIST_MULTITHREAD_ISSUE,        /**< Error: Multithreading issue*/
-	LLIST_ERROR,			/**< Error: Generic error*/
+	LLIST_ERROR			/**< Error: Generic error*/
 } E_LLIST;
 
 #define ADD_NODE_FRONT		(1 << 0)
@@ -153,7 +153,7 @@ int llist_find_node ( llist list, void * data, llist_node * found, equal alterna
 /**
  * @brief operate on each element of the list, not thread safe if func modifies node contents
  * @param[in] list the list to operator upon
- * @param[in] func
+ * @param[in] func the function to perform
  * @return int LLIST_SUCCESS if success
  */
 int llist_for_each ( llist list, node_func func );

--- a/inc/llist.h
+++ b/inc/llist.h
@@ -102,13 +102,11 @@ llist llist_create ( comperator compare_func, equal equal_func, unsigned flags )
 
 /**
  * @brief set abort condition 
- * @param[in] compare_func a function used to compare elements in the list
- * @param[in] equal_func a function used to check if two elements are equal
- * @param[in] flags used to identify whether we create a thread safe linked-list
- * @return new list if success, NULL on error
+ * @param[in] list The list to act on
+ * @param[in] cond to abort iterations on each node of the linked list
+ * @return SUCESS on success or NULL on failure 
  */
-
-int llist_abort_looping( llist list );
+int llist_set_abort_condition( llist list , E_LLIST_LOOP_CONDITION cond );
 
 /**
  * @brief Destroys a list

--- a/inc/llist.h
+++ b/inc/llist.h
@@ -100,14 +100,21 @@ typedef bool ( * equal ) ( llist_node, llist_node );
  */
 llist llist_create ( comperator compare_func, equal equal_func, unsigned flags );
 
-
 /**
  * @brief set abort condition 
  * @param[in] list The list to act on
  * @param[in] cond to abort iterations on each node of the linked list
- * @return SUCESS on success or NULL on failure 
+ * @return SUCESS on success or failure codes on failure 
  */
 int llist_set_abort_condition( llist list , E_LLIST_LOOP_CONDITION cond );
+
+/**
+ * @brief get abort condition 
+ * @param[in] list The list to act on
+ * @param[in] cond pointer
+ * @return SUCESS on success or failure codes on failure 
+ */
+int llist_get_abort_condition( llist list , E_LLIST_LOOP_CONDITION* cond);
 
 /**
  * @brief Destroys a list
@@ -116,10 +123,9 @@ int llist_set_abort_condition( llist list , E_LLIST_LOOP_CONDITION cond );
  * @param[in] list The list to destroy
  * @param[in] destroy_nodes true if the nodes should be destroyed, false if not
  * @param[in] destructor alternative destructor, if the previous param is true,
- *			  if NULL is provided standard library c free() will be used
+ *			 if NULL is provided standard library c free() will be used
  */
 void llist_destroy ( llist list, bool destroy_nodes, node_func destructor);
-
 
 /**
  * @brief Add a node to a list

--- a/inc/llist.h
+++ b/inc/llist.h
@@ -35,7 +35,8 @@ typedef enum
 	LLIST_MALLOC_ERROR,				/**< Error: Memory allocation error*/
         LLIST_NOT_IMPLEMENTED,          /**< Error: Implementation missing*/
         LLIST_MULTITHREAD_ISSUE,        /**< Error: Multithreading issue*/
-	LLIST_ERROR			/**< Error: Generic error*/
+	LLIST_ERROR,			/**< Error: Generic error*/
+	LLIST_ITERARTIONS_ABORTED      /*code indicated iterations on the linked list was aborted*/
 } E_LLIST;
 
 #define ADD_NODE_FRONT		(1 << 0)
@@ -53,7 +54,7 @@ typedef enum
 typedef enum
 {
     LOOP_ABORT_FALSE = 0, 
-    LOOP_ABORT_TRUE
+    LOOP_ABORT_TRUE, 
 }E_LLIST_LOOP_CONDITION;
 
 #undef TRUE

--- a/inc/llist.h
+++ b/inc/llist.h
@@ -50,8 +50,11 @@ typedef enum
 #define MT_SUPPORT_TRUE  (1)
 #define MT_SUPPORT_FALSE (0)
 
-#define LOOP_ABORT_TRUE (1)
-#define LOOP_ABORT_FALSE (1)
+typedef enum
+{
+    LOOP_ABORT_FALSE = 0, 
+    LOOP_ABORT_TRUE
+}E_LLIST_LOOP_CONDITION;
 
 #undef TRUE
 #undef FALSE
@@ -95,6 +98,17 @@ typedef bool ( * equal ) ( llist_node, llist_node );
  * @return new list if success, NULL on error
  */
 llist llist_create ( comperator compare_func, equal equal_func, unsigned flags );
+
+
+/**
+ * @brief set abort condition 
+ * @param[in] compare_func a function used to compare elements in the list
+ * @param[in] equal_func a function used to check if two elements are equal
+ * @param[in] flags used to identify whether we create a thread safe linked-list
+ * @return new list if success, NULL on error
+ */
+
+int llist_abort_looping( llist list );
 
 /**
  * @brief Destroys a list

--- a/src/llist.c
+++ b/src/llist.c
@@ -368,7 +368,7 @@ int llist_for_each ( llist list, node_func func )
     while ( iterator != NULL )
     {
         if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
-            return LLIST_SUCCESS;
+            return LLIST_ITERARTIONS_ABORTED;
 
         //func should only read the node but not modify its contents
 	//user should ensure thread safety
@@ -397,7 +397,7 @@ int llist_for_each_arg_read_only ( llist list, node_func_arg r_only_func, void *
        if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
        {
            UNLOCK( list, LLIST_MULTITHREAD_ISSUE )
-           return LLIST_SUCCESS;
+           return LLIST_ITERARTIONS_ABORTED;
        }
        //func should only read the node but not modify its contents
        r_only_func ( iterator->node , arg);
@@ -428,7 +428,7 @@ int llist_for_each_arg ( llist list, node_func_arg func, void * arg )
         if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
         {
            UNLOCK( list, LLIST_MULTITHREAD_ISSUE )
-           return LLIST_SUCCESS;
+           return LLIST_ITERARTIONS_ABORTED;
         }
         //func can not only read the node but also modify its contents
         func ( iterator->node , arg);

--- a/src/llist.c
+++ b/src/llist.c
@@ -132,6 +132,14 @@ int llist_set_abort_condition( llist list , E_LLIST_LOOP_CONDITION cond )
     return LLIST_SUCCESS; 
 }
 
+int llist_get_abort_condition( llist list , E_LLIST_LOOP_CONDITION* cond)
+{
+    if ( NULL == list ) return LLIST_NULL_ARGUMENT;
+
+    *cond = ( ( _llist * ) list )->should_abort_looping;
+    return LLIST_SUCCESS; 
+}
+
 void llist_destroy ( llist list, bool destroy_nodes, node_func destructor )
 {
     _list_node *iterator;

--- a/src/llist.c
+++ b/src/llist.c
@@ -124,11 +124,11 @@ llist llist_create ( comperator compare_func, equal equal_func, unsigned flags)
 }
 
 
-int llist_abort_looping( llist list )
+int set_abort_condition( llist list , E_LLIST_LOOP_CONDITION cond )
 {
     if ( NULL == list ) return LLIST_NULL_ARGUMENT; 
-  
-    ( ( _llist * ) list )->should_abort_looping = LOOP_ABORT_TRUE;
+
+    ( ( _llist * ) list )->should_abort_looping = cond;
     return LLIST_SUCCESS; 
 }
 

--- a/src/llist.c
+++ b/src/llist.c
@@ -124,7 +124,7 @@ llist llist_create ( comperator compare_func, equal equal_func, unsigned flags)
 }
 
 
-int set_abort_condition( llist list , E_LLIST_LOOP_CONDITION cond )
+int llist_set_abort_condition( llist list , E_LLIST_LOOP_CONDITION cond )
 {
     if ( NULL == list ) return LLIST_NULL_ARGUMENT; 
 

--- a/src/llist.c
+++ b/src/llist.c
@@ -362,24 +362,19 @@ int llist_for_each ( llist list, node_func func )
         return LLIST_NULL_ARGUMENT;
     }
 
+
+    iterator = ( ( _llist * ) list )->head;
+
+    while ( iterator != NULL )
     {
-
         if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
-        {
-	    return LLIST_SUCCESS;
-        }
+            return LLIST_SUCCESS;
 
-        iterator = ( ( _llist * ) list )->head;
-
-        while ( iterator != NULL )
-        {
-            //func should only read the node but node modify its contents
-	    //user should ensure thread safety
-            func ( iterator->node );
-            iterator = iterator->next;
-        }
+        //func should only read the node but not modify its contents
+	//user should ensure thread safety
+        func ( iterator->node );
+        iterator = iterator->next;
     }
-
     return LLIST_SUCCESS;
 }
 
@@ -394,21 +389,19 @@ int llist_for_each_arg_read_only ( llist list, node_func_arg r_only_func, void *
 
     READ_LOCK( list, LLIST_MULTITHREAD_ISSUE )
 
+
+    iterator = ( ( _llist * ) list )->head;
+
+    while ( iterator != NULL )
     {
-
-        if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
-        {
-            UNLOCK( list, LLIST_MULTITHREAD_ISSUE )
-	    return LLIST_SUCCESS;
-        }
-
-        iterator = ( ( _llist * ) list )->head;
-
-        while ( iterator != NULL )
-        {
-            r_only_func ( iterator->node , arg);
-            iterator = iterator->next;
-        }
+       if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
+       {
+           UNLOCK( list, LLIST_MULTITHREAD_ISSUE )
+           return LLIST_SUCCESS;
+       }
+       //func should only read the node but not modify its contents
+       r_only_func ( iterator->node , arg);
+       iterator = iterator->next;
     }
 
     UNLOCK( list, LLIST_MULTITHREAD_ISSUE )
@@ -428,21 +421,18 @@ int llist_for_each_arg ( llist list, node_func_arg func, void * arg )
 
     WRITE_LOCK( list, LLIST_MULTITHREAD_ISSUE )
 
+    iterator = ( ( _llist * ) list )->head;
+
+    while ( iterator != NULL )
     {
-
-	if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
+        if ( ( ( _llist * ) list )->should_abort_looping == LOOP_ABORT_TRUE )
         {
-            UNLOCK( list, LLIST_MULTITHREAD_ISSUE )
-	    return LLIST_SUCCESS;
+           UNLOCK( list, LLIST_MULTITHREAD_ISSUE )
+           return LLIST_SUCCESS;
         }
-
-        iterator = ( ( _llist * ) list )->head;
-
-        while ( iterator != NULL )
-        {
-            func ( iterator->node , arg);
-            iterator = iterator->next;
-        }
+        //func can not only read the node but also modify its contents
+        func ( iterator->node , arg);
+        iterator = iterator->next;
     }
 
     UNLOCK( list, LLIST_MULTITHREAD_ISSUE )


### PR DESCRIPTION

1. Currently the function acting on the nodes when they iterate must be read-only wrt the contents of the node, so introduced a R/W version.

2.  During application module un-init or thread restart, finishing the iterations on the list items takes a very long time(especially when the function call backs on the nodes are large operations) so introduced a small feature to abort iterations from a different thread.

 